### PR TITLE
fix: simplify deploy workflow and fix istio test eks-v2 compat

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,33 +107,8 @@ jobs:
             echo "PR #$PR_NUMBER has no approved review for SHA $SHA - skipping deploy"
             echo "is_approved=false" >> "$GITHUB_OUTPUT"
           fi
-  create-deployment:
-    needs: resolve
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      deployments: write
-    outputs:
-      deployment_id: ${{ steps.create.outputs.deployment_id }}
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      REF: ${{ needs.resolve.outputs.ref }}
-      REPO: ${{ github.repository }}
-    if: needs.resolve.outputs.is_approved == 'true' && needs.resolve.outputs.build_ok == 'true'
-    steps:
-      - name: Create deployment
-        id: create
-        run: |-
-          set -eu
-          jq -nc --arg ref "$REF" '{ref: $ref, environment: "AWS", auto_merge: false, required_contexts: []}' > /tmp/deployment.json
-          echo "Payload:"; cat /tmp/deployment.json
-          DEPLOYMENT_ID=$(gh api "repos/$REPO/deployments" --method POST --input /tmp/deployment.json --jq .id)
-          echo "deployment_id=$DEPLOYMENT_ID" >> "$GITHUB_OUTPUT"
-          echo "Created deployment: $DEPLOYMENT_ID"
   build-from-main:
-    needs:
-      - resolve
-      - create-deployment
+    needs: resolve
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
@@ -170,7 +145,6 @@ jobs:
   deploy:
     needs:
       - resolve
-      - create-deployment
       - build-from-main
     runs-on: ubuntu-latest
     permissions:
@@ -185,7 +159,7 @@ jobs:
       BUCKET: ${{ secrets.BUCKET }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
       DEPLOYMENT_ROLE: ${{ secrets.DEPLOYMENT_ROLE }}
-    if: always() && needs.resolve.result == 'success' && needs.create-deployment.result == 'success' && (needs.build-from-main.result == 'success' || needs.build-from-main.result == 'skipped')
+    if: always() && needs.resolve.result == 'success' && needs.resolve.outputs.is_approved == 'true' && needs.resolve.outputs.build_ok == 'true' && (needs.build-from-main.result == 'success' || needs.build-from-main.result == 'skipped')
     steps:
       - name: Checkout main (trusted)
         uses: actions/checkout@v4
@@ -213,28 +187,6 @@ jobs:
           mask-aws-account-id: true
       - name: Deploy workshop to AWS
         run: npx projen deploy
-  report-deployment:
-    needs:
-      - resolve
-      - create-deployment
-      - deploy
-    runs-on: ubuntu-latest
-    permissions:
-      deployments: write
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    if: always() && needs.create-deployment.result == 'success'
-    steps:
-      - name: Report deployment status
-        run: |-
-          if [ "${{ needs.deploy.result }}" == "success" ]; then
-                      STATE="success"
-                    else
-                      STATE="failure"
-                    fi
-                    gh api repos/${{ github.repository }}/deployments/${{ needs.create-deployment.outputs.deployment_id }}/statuses \
-                      -f state=$STATE
-                    echo "Deployment status: $STATE"
 concurrency:
   group: deploy-${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha || github.sha }}
   cancel-in-progress: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: lts/*
-          package-manager-cache: "false"
+          package-manager-cache: false
       - name: Download build artifacts
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: lts/*
-          package-manager-cache: false
+          package-manager-cache: "false"
       - name: Download build artifacts
         uses: actions/download-artifact@v8
         with:

--- a/projenrc/workflows/deploy-workflow.ts
+++ b/projenrc/workflows/deploy-workflow.ts
@@ -306,4 +306,3 @@ function addDeployJob(workflow: GithubWorkflow): void {
 }
 
 
-

--- a/projenrc/workflows/deploy-workflow.ts
+++ b/projenrc/workflows/deploy-workflow.ts
@@ -62,10 +62,8 @@ export function createDeployWorkflow(github: GitHub): void {
   ].join(' || ');
 
   addResolveJob(workflow, gate);
-  addCreateDeploymentJob(workflow);
   addBuildFromMainJob(workflow);
   addDeployJob(workflow);
-  addReportDeploymentJob(workflow);
 }
 
 
@@ -193,49 +191,11 @@ function addResolveJob(workflow: GithubWorkflow, gate: string): void {
   });
 }
 
-function addCreateDeploymentJob(workflow: GithubWorkflow): void {
-  workflow.addJob('create-deployment', {
-    needs: ['resolve'],
-    // Only proceed if the resolve job cleared approval and build checks.
-    // Unapproved PRs result in this and all downstream jobs being skipped
-    // (grey dot), not failed (red X).
-    if: "needs.resolve.outputs.is_approved == 'true' && needs.resolve.outputs.build_ok == 'true'",
-    runsOn: ['ubuntu-latest'],
-    permissions: {
-      contents: JobPermission.READ,
-      deployments: JobPermission.WRITE,
-    },
-    outputs: {
-      deployment_id: { stepId: 'create', outputName: 'deployment_id' },
-    },
-    env: {
-      GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}',
-      REF: '${{ needs.resolve.outputs.ref }}',
-      REPO: '${{ github.repository }}',
-    },
-    steps: [
-      {
-        name: 'Create deployment',
-        id: 'create',
-        run: [
-          'set -eu',
-          'jq -nc --arg ref "$REF" \'{ref: $ref, environment: "AWS", auto_merge: false, required_contexts: []}\' > /tmp/deployment.json',
-          'echo "Payload:"; cat /tmp/deployment.json',
-          'DEPLOYMENT_ID=$(gh api "repos/$REPO/deployments" --method POST --input /tmp/deployment.json --jq .id)',
-          'echo "deployment_id=$DEPLOYMENT_ID" >> "$GITHUB_OUTPUT"',
-          'echo "Created deployment: $DEPLOYMENT_ID"',
-        ].join('\n'),
-      },
-    ],
-  });
-}
-
-
 // Builds dist/content.zip from main (trusted) on manual dispatch only. Uploads
 // the artifact so the deploy job has a uniform input source regardless of trigger.
 function addBuildFromMainJob(workflow: GithubWorkflow): void {
   workflow.addJob('build-from-main', {
-    needs: ['resolve', 'create-deployment'],
+    needs: ['resolve'],
     if: "github.event_name == 'workflow_dispatch'",
     runsOn: ['ubuntu-24.04-arm'],
     permissions: { contents: JobPermission.READ },
@@ -282,10 +242,10 @@ function addBuildFromMainJob(workflow: GithubWorkflow): void {
 // run for workflow_run) and calls aws CLI against it.
 function addDeployJob(workflow: GithubWorkflow): void {
   workflow.addJob('deploy', {
-    needs: ['resolve', 'create-deployment', 'build-from-main'],
+    needs: ['resolve', 'build-from-main'],
     // build-from-main is skipped on workflow_run; only fail if it was required
     // and failed. Use always() + explicit skip-aware condition.
-    if: "always() && needs.resolve.result == 'success' && needs.create-deployment.result == 'success' && (needs.build-from-main.result == 'success' || needs.build-from-main.result == 'skipped')",
+    if: "always() && needs.resolve.result == 'success' && needs.resolve.outputs.is_approved == 'true' && needs.resolve.outputs.build_ok == 'true' && (needs.build-from-main.result == 'success' || needs.build-from-main.result == 'skipped')",
     runsOn: ['ubuntu-latest'],
     permissions: {
       contents: JobPermission.READ,
@@ -346,27 +306,4 @@ function addDeployJob(workflow: GithubWorkflow): void {
 }
 
 
-function addReportDeploymentJob(workflow: GithubWorkflow): void {
-  workflow.addJob('report-deployment', {
-    needs: ['resolve', 'create-deployment', 'deploy'],
-    if: "always() && needs.create-deployment.result == 'success'",
-    runsOn: ['ubuntu-latest'],
-    permissions: { deployments: JobPermission.WRITE },
-    env: { GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}' },
-    steps: [
-      {
-        name: 'Report deployment status',
-        run: `
-          if [ "\${{ needs.deploy.result }}" == "success" ]; then
-            STATE="success"
-          else
-            STATE="failure"
-          fi
-          gh api repos/\${{ github.repository }}/deployments/\${{ needs.create-deployment.outputs.deployment_id }}/statuses \\
-            -f state=$STATE
-          echo "Deployment status: $STATE"
-        `.trim(),
-      },
-    ],
-  });
-}
+

--- a/test/cdk/constructs/istio.test.ts
+++ b/test/cdk/constructs/istio.test.ts
@@ -5,7 +5,7 @@ import { KubectlV35Layer } from '@aws-cdk/lambda-layer-kubectl-v35';
 import * as cdk from 'aws-cdk-lib';
 import { Match } from 'aws-cdk-lib/assertions';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
-import * as eks from 'aws-cdk-lib/aws-eks';
+import * as eks from 'aws-cdk-lib/aws-eks-v2';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import { ContainerAndRepo } from '../../../src/cdk/lib/constructs/container-and-repo';
 import { Istio } from '../../../src/cdk/lib/constructs/istio';
@@ -37,6 +37,7 @@ describe('Istio', () => {
       vpc: sharedVpc,
       version: eks.KubernetesVersion.of('1.35'),
       defaultCapacity: 0,
+      defaultCapacityType: eks.DefaultCapacityType.NODEGROUP,
       kubectlProviderOptions: { kubectlLayer: new KubectlV35Layer(sharedStack, 'KubectlLayer') },
     });
 
@@ -244,6 +245,7 @@ describe('Istio', () => {
         vpc,
         version: eks.KubernetesVersion.of('1.35'),
         defaultCapacity: 0,
+        defaultCapacityType: eks.DefaultCapacityType.NODEGROUP,
         kubectlProviderOptions: { kubectlLayer: new KubectlV35Layer(stack, 'KubectlLayer') },
       });
       const assetsBucket = new s3.Bucket(stack, 'AssetsBucket', {
@@ -339,6 +341,7 @@ describe('Istio', () => {
           vpc,
           version: eks.KubernetesVersion.of('1.35'),
           defaultCapacity: 0,
+          defaultCapacityType: eks.DefaultCapacityType.NODEGROUP,
           kubectlProviderOptions: { kubectlLayer: new KubectlV35Layer(customVersionStack, 'KubectlLayer') },
         });
         const assetsBucket = new s3.Bucket(customVersionStack, 'AssetsBucket', {


### PR DESCRIPTION
## Summary

- **Deploy workflow**: Removed manual deployment management (`create-deployment` and `report-deployment` jobs). The deploy job now relies on GitHub's auto-created deployment via the `environment` attribute, which ties the deployment to the correct SHA (PR head for PR-triggered runs, main for manual dispatch). This fixes the issue where two deployments were created per run, causing the PR's deployment to be marked inactive and blocking merge (PR #227).

- **Istio test**: Changed import from `aws-cdk-lib/aws-eks` to `aws-cdk-lib/aws-eks-v2` to match the `Istio` construct's dependency. Added `defaultCapacityType: eks.DefaultCapacityType.NODEGROUP` since eks-v2 defaults to Auto Mode which doesn't allow `defaultCapacity: 0`.

## Testing

- `npx tsc --noEmit` passes
- `npx jest test/cdk/constructs/istio.test.ts` — all 36 tests pass