### PR TITLE
fix: use manual deployment with auto_inactive=false

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,8 +107,33 @@ jobs:
             echo "PR #$PR_NUMBER has no approved review for SHA $SHA - skipping deploy"
             echo "is_approved=false" >> "$GITHUB_OUTPUT"
           fi
-  build-from-main:
+  create-deployment:
     needs: resolve
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    outputs:
+      deployment_id: ${{ steps.create.outputs.deployment_id }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REF: ${{ needs.resolve.outputs.ref }}
+      REPO: ${{ github.repository }}
+    if: needs.resolve.outputs.is_approved == 'true' && needs.resolve.outputs.build_ok == 'true'
+    steps:
+      - name: Create deployment
+        id: create
+        run: |-
+          set -eu
+          jq -nc --arg ref "$REF" '{ref: $ref, environment: "AWS", auto_merge: false, required_contexts: [], auto_inactive: false}' > /tmp/deployment.json
+          echo "Payload:"; cat /tmp/deployment.json
+          DEPLOYMENT_ID=$(gh api "repos/$REPO/deployments" --method POST --input /tmp/deployment.json --jq .id)
+          echo "deployment_id=$DEPLOYMENT_ID" >> "$GITHUB_OUTPUT"
+          echo "Created deployment: $DEPLOYMENT_ID"
+  build-from-main:
+    needs:
+      - resolve
+      - create-deployment
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
@@ -145,21 +170,20 @@ jobs:
   deploy:
     needs:
       - resolve
+      - create-deployment
       - build-from-main
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
       actions: read
-    environment:
-      name: AWS
     env:
       CI: "true"
       PROJECT_NAME: ${{ github.event.repository.name }}
       BUCKET: ${{ secrets.BUCKET }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
       DEPLOYMENT_ROLE: ${{ secrets.DEPLOYMENT_ROLE }}
-    if: always() && needs.resolve.result == 'success' && needs.resolve.outputs.is_approved == 'true' && needs.resolve.outputs.build_ok == 'true' && (needs.build-from-main.result == 'success' || needs.build-from-main.result == 'skipped')
+    if: always() && needs.resolve.result == 'success' && needs.create-deployment.result == 'success' && (needs.build-from-main.result == 'success' || needs.build-from-main.result == 'skipped')
     steps:
       - name: Checkout main (trusted)
         uses: actions/checkout@v4
@@ -187,6 +211,28 @@ jobs:
           mask-aws-account-id: true
       - name: Deploy workshop to AWS
         run: npx projen deploy
+  report-deployment:
+    needs:
+      - resolve
+      - create-deployment
+      - deploy
+    runs-on: ubuntu-latest
+    permissions:
+      deployments: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    if: always() && needs.create-deployment.result == 'success'
+    steps:
+      - name: Report deployment status
+        run: |-
+          if [ "${{ needs.deploy.result }}" == "success" ]; then
+            STATE="success"
+          else
+            STATE="failure"
+          fi
+          gh api repos/${{ github.repository }}/deployments/${{ needs.create-deployment.outputs.deployment_id }}/statuses \
+            -f state=$STATE
+          echo "Deployment status: $STATE"
 concurrency:
   group: deploy-${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha || github.sha }}
   cancel-in-progress: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: lts/*
-          package-manager-cache: "false"
+          package-manager-cache: false
       - name: Download build artifacts
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: lts/*
-          package-manager-cache: false
+          package-manager-cache: "false"
       - name: Download build artifacts
         uses: actions/download-artifact@v8
         with:

--- a/projenrc/workflows/deploy-workflow.ts
+++ b/projenrc/workflows/deploy-workflow.ts
@@ -62,8 +62,10 @@ export function createDeployWorkflow(github: GitHub): void {
   ].join(' || ');
 
   addResolveJob(workflow, gate);
+  addCreateDeploymentJob(workflow);
   addBuildFromMainJob(workflow);
   addDeployJob(workflow);
+  addReportDeploymentJob(workflow);
 }
 
 
@@ -191,11 +193,46 @@ function addResolveJob(workflow: GithubWorkflow, gate: string): void {
   });
 }
 
+function addCreateDeploymentJob(workflow: GithubWorkflow): void {
+  workflow.addJob('create-deployment', {
+    needs: ['resolve'],
+    if: "needs.resolve.outputs.is_approved == 'true' && needs.resolve.outputs.build_ok == 'true'",
+    runsOn: ['ubuntu-latest'],
+    permissions: {
+      contents: JobPermission.READ,
+      deployments: JobPermission.WRITE,
+    },
+    outputs: {
+      deployment_id: { stepId: 'create', outputName: 'deployment_id' },
+    },
+    env: {
+      GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}',
+      REF: '${{ needs.resolve.outputs.ref }}',
+      REPO: '${{ github.repository }}',
+    },
+    steps: [
+      {
+        name: 'Create deployment',
+        id: 'create',
+        run: [
+          'set -eu',
+          'jq -nc --arg ref "$REF" \'{ref: $ref, environment: "AWS", auto_merge: false, required_contexts: [], auto_inactive: false}\' > /tmp/deployment.json',
+          'echo "Payload:"; cat /tmp/deployment.json',
+          'DEPLOYMENT_ID=$(gh api "repos/$REPO/deployments" --method POST --input /tmp/deployment.json --jq .id)',
+          'echo "deployment_id=$DEPLOYMENT_ID" >> "$GITHUB_OUTPUT"',
+          'echo "Created deployment: $DEPLOYMENT_ID"',
+        ].join('\n'),
+      },
+    ],
+  });
+}
+
+
 // Builds dist/content.zip from main (trusted) on manual dispatch only. Uploads
 // the artifact so the deploy job has a uniform input source regardless of trigger.
 function addBuildFromMainJob(workflow: GithubWorkflow): void {
   workflow.addJob('build-from-main', {
-    needs: ['resolve'],
+    needs: ['resolve', 'create-deployment'],
     if: "github.event_name == 'workflow_dispatch'",
     runsOn: ['ubuntu-24.04-arm'],
     permissions: { contents: JobPermission.READ },
@@ -242,17 +279,16 @@ function addBuildFromMainJob(workflow: GithubWorkflow): void {
 // run for workflow_run) and calls aws CLI against it.
 function addDeployJob(workflow: GithubWorkflow): void {
   workflow.addJob('deploy', {
-    needs: ['resolve', 'build-from-main'],
+    needs: ['resolve', 'create-deployment', 'build-from-main'],
     // build-from-main is skipped on workflow_run; only fail if it was required
     // and failed. Use always() + explicit skip-aware condition.
-    if: "always() && needs.resolve.result == 'success' && needs.resolve.outputs.is_approved == 'true' && needs.resolve.outputs.build_ok == 'true' && (needs.build-from-main.result == 'success' || needs.build-from-main.result == 'skipped')",
+    if: "always() && needs.resolve.result == 'success' && needs.create-deployment.result == 'success' && (needs.build-from-main.result == 'success' || needs.build-from-main.result == 'skipped')",
     runsOn: ['ubuntu-latest'],
     permissions: {
       contents: JobPermission.READ,
       idToken: JobPermission.WRITE,
       actions: JobPermission.READ,
     },
-    environment: { name: 'AWS' },
     env: {
       CI: 'true',
       PROJECT_NAME: '${{ github.event.repository.name }}',
@@ -300,6 +336,32 @@ function addDeployJob(workflow: GithubWorkflow): void {
       {
         name: 'Deploy workshop to AWS',
         run: 'npx projen deploy',
+      },
+    ],
+  });
+}
+
+
+function addReportDeploymentJob(workflow: GithubWorkflow): void {
+  workflow.addJob('report-deployment', {
+    needs: ['resolve', 'create-deployment', 'deploy'],
+    if: "always() && needs.create-deployment.result == 'success'",
+    runsOn: ['ubuntu-latest'],
+    permissions: { deployments: JobPermission.WRITE },
+    env: { GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}' },
+    steps: [
+      {
+        name: 'Report deployment status',
+        run: [
+          'if [ "${{ needs.deploy.result }}" == "success" ]; then',
+          '  STATE="success"',
+          'else',
+          '  STATE="failure"',
+          'fi',
+          'gh api repos/${{ github.repository }}/deployments/${{ needs.create-deployment.outputs.deployment_id }}/statuses \\',
+          '  -f state=$STATE',
+          'echo "Deployment status: $STATE"',
+        ].join('\n'),
       },
     ],
   });


### PR DESCRIPTION
## Problem

PR #229 switched to using the `environment` attribute on the deploy job to let GitHub auto-manage deployments. However, `workflow_run` events run in the context of the default branch — so GitHub's auto-created deployment uses main's `head_sha`, not the PR's SHA. This means the `required_deployments` ruleset never sees a deployment for the PR's commit.

Additionally, when multiple deployments succeed for the same environment, GitHub auto-deactivates prior ones, which was the original issue blocking PR #227.

## Fix

- **Manual deployment management**: Restore `create-deployment` and `report-deployment` jobs that explicitly create a single deployment using the resolved ref (PR SHA for PR-triggered runs, main for manual dispatch).
- **`auto_inactive: false`**: Prevents GitHub from deactivating a PR's deployment when a subsequent deployment (e.g., for another PR) succeeds.
- **No `environment` attribute**: Removed from the deploy job to prevent GitHub from auto-creating a second deployment tied to the wrong SHA.

## Testing

- `npx tsc --noEmit` passes
- Generated workflow verified: single deployment per run, correct ref, no auto-deactivation