### PR TITLE
fix: include content.zip in S3 asset upload

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,7 @@ jobs:
         run: |-
           mkdir -p extracted
           unzip -q content.zip -d extracted
+          cp content.zip extracted/
       - name: Upload assets to S3
         run: aws s3 sync extracted "$ASSETS_LOCATION" --delete
   publish-workshop:

--- a/projenrc/workflows/publish-workflow.ts
+++ b/projenrc/workflows/publish-workflow.ts
@@ -80,7 +80,8 @@ gh release download \${{ steps.release-info.outputs.tag }} \\
       {
         name: 'Extract content.zip',
         run: `mkdir -p extracted
-unzip -q content.zip -d extracted`,
+unzip -q content.zip -d extracted
+cp content.zip extracted/`,
       },
       {
         name: 'Upload assets to S3',


### PR DESCRIPTION
The publish workflow extracts content.zip and syncs the extracted contents to S3, but never uploads content.zip itself. The workshop references it via `:assetUrl{path=/content.zip source=s3}`.

The old workflow (pre-refactor) included content.zip in the assets directory before syncing. This restores that behavior by copying content.zip into the extracted directory before the sync, so it's part of the managed set and not removed by `--delete`.