### PR TITLE
fix: force workshop version change on every publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -104,15 +104,10 @@ jobs:
           cp -r ${{ github.workspace }}/static ./
           cp ${{ github.workspace }}/contentspec.yaml ./
 
-          # Check for changes and commit if any exist
-          set +e
-          git diff --quiet
-          if [ $? -eq 1 ]; then
-            set -e
-            git add -A
-            git commit -m "Published from release ${{ needs.upload-assets.outputs.release_tag }}"
-            git push
-            echo "✅ Workshop content published successfully"
-          else
-            echo "ℹ️ No changes detected, nothing to commit"
-          fi
+          # Write release tag to force a change even if content is identical
+          echo "${{ needs.upload-assets.outputs.release_tag }}" > .version
+
+          git add -A
+          git commit -m "Published from release ${{ needs.upload-assets.outputs.release_tag }}"
+          git push
+          echo "✅ Workshop content published successfully"

--- a/projenrc/workflows/publish-workflow.ts
+++ b/projenrc/workflows/publish-workflow.ts
@@ -150,18 +150,13 @@ cp -r \${{ github.workspace }}/content ./
 cp -r \${{ github.workspace }}/static ./
 cp \${{ github.workspace }}/contentspec.yaml ./
 
-# Check for changes and commit if any exist
-set +e
-git diff --quiet
-if [ $? -eq 1 ]; then
-  set -e
-  git add -A
-  git commit -m "Published from release \${{ needs.upload-assets.outputs.release_tag }}"
-  git push
-  echo "✅ Workshop content published successfully"
-else
-  echo "ℹ️ No changes detected, nothing to commit"
-fi`,
+# Write release tag to force a change even if content is identical
+echo "\${{ needs.upload-assets.outputs.release_tag }}" > .version
+
+git add -A
+git commit -m "Published from release \${{ needs.upload-assets.outputs.release_tag }}"
+git push
+echo "✅ Workshop content published successfully"`,
       },
     ],
   });


### PR DESCRIPTION
The publish workflow was detecting no changes when pushing to Workshop Studio's CodeCommit repo, which prevented a new version from being created.

This writes the release tag to a `.version` file before committing, ensuring there's always a diff and Workshop Studio recognizes a new version.